### PR TITLE
Fixup language describing a normative string literal.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -372,10 +372,10 @@ contributors: Daniel Ehrenberg
         </td>
         <td>
           <emu-alg>
-            1. <ins>If _namedCaptures_ is *undefined*, the replacement text is the literal string `$&lt;`.</ins>
+            1. <ins>If _namedCaptures_ is *undefined*, the replacement text is the String `"$&lt;"`.</ins>
             1. <ins>Otherwise,</ins>
               1. <ins>Scan until the next `>`.</ins>
-              1. <ins>If none is found, the replacement text is the literal string `$&lt;`.</ins>
+              1. <ins>If none is found, the replacement text is the String `"$&lt;"`.</ins>
               1. <ins>Otherwise,</ins>
                 1. <ins>Let the enclosed substring be _groupName_.</ins>
                 1. <ins>Let _capture_ be ? Get(_namedCaptures_, _groupName_).</ins>


### PR DESCRIPTION
From https://github.com/tc39/proposal-regexp-named-groups/commit/92ceba518c2ab0d2811c2efa8248ed1b3f8b5506: 

When describing a string literal, the language used in ECMA-262 is "the string literal" or "the String" followed by the actual string, in quotes with fixed width font. The former only appears in non-normative prose, while the latter appears in algorithm steps. This should read: 


> the String \`"$&lt;"\`