### PR TITLE
Normative: Create a groups property unconditionally

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -205,7 +205,9 @@ contributors: Daniel Ehrenberg
     1. Perform ! CreateDataProperty(_A_, `"0"`, _matchedSubstr_).
     1. <ins>If _R_ contains any |GroupName|, then</ins>
       1. <ins>Let _groups_ be ObjectCreate(*null*).</ins>
-      1. <ins>Perform ! CreateDataProperty(_A_, `"groups"`, _groups_).</ins>
+    1. <ins>Else,</ins>
+      1. <ins>Let _groups_ be *undefined*.</ins>
+    1. <ins>Perform ! CreateDataProperty(_A_, `"groups"`, _groups_).</ins>
     1. For each integer _i_ such that _i_ &gt; 0 and _i_ &le; _n_
       1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
       1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.


### PR DESCRIPTION
If the RegExp does not have named groups, set a groups property
of the result to undefined. This change is made to facilitate
optimizing RegExp implementations, which often take a "fast path"
for built-in, unmodified to not incur the overhead of the full
subclassable semantics. If the "groups" property may be read
from higher up on the prototype chain, the fast path for
RegExp.prototype.replace would become more complex or slower, or
alternatively, more conditions about the environment might need
to be checked as a precondition to apply the fast path.

An alternate approach would be to only read an own groups property
based on a HasOwnProperty test followed by a Get. I don't see big
advantages or disadvantages to that approach vs this one, and I'd
be fine to revisit this patch if more differentiating factors
are raised before Stage 4.

Closes #34